### PR TITLE
Better metadata field evaluation + handling of empty wisky file

### DIFF
--- a/R/dB_readZRX.R
+++ b/R/dB_readZRX.R
@@ -41,20 +41,28 @@ dB_readZRX <- function(file, do.hourly=FALSE, do.quality=FALSE, chron=TRUE, mult
     st_name <- strsplit( x = header[ grep("#SNAME",header) ], split = ";")[[1]][1]
     st_name <- substr(st_name, 7, nchar(st_name))
     
+    st_id <- strsplit( x = header[ grep("#SNAME",header) ], split = ";")[[1]][3]
+    st_id <- substr(st_id, 5, nchar(st_id))
+    
     rexchange <- strsplit( x = header[ grep("#REXCHANGE",header) ], split = ";")[[1]][1]
-    st_id <- substr(rexchange, 11, 14)
+    rexchange <- substr(rexchange, 11, nchar(rexchange))
     
     # get variable info
-    var_name <- substr(rexchange, 15, nchar(rexchange))
+    var_name <- strsplit( x = header[ grep("#CNAME",header) ], split = ";")[[1]][1]
+    var_name <- substr(var_name, 7, nchar(var_name))
+    
+    var_time <- strsplit( x = header[ grep("#TSNAME",header) ], split = ";")[[1]][1]
+    var_time <- substr(var_time, 9, nchar(var_time))
     
     # get time step in minutes
-    if (length( grep("5A", var_name ) )==1) time_scale <- 5
-    if (length( grep("10A", var_name) )==1) time_scale <- 10
-    if (length( grep("60A", var_name) )==1) time_scale <- 60
-    if (length( grep("TAG", var_name) )==1) time_scale <- 60*24
+    if (length( grep("5", var_time ) )==1) time_scale <- 5
+    if (length( grep("10", var_time) )==1) time_scale <- 10
+    if (length( grep("30", var_time) )==1) time_scale <- 30
+    if (length( grep("60", var_time) )==1) time_scale <- 60
+    if (length( grep("TAG", var_time,ignore.case = T) )==1) time_scale <- 60*24
     
     # meta data vector
-    meta_mat <- rbind(meta_mat, c(st_id=st_id, st_name=st_name, var_name=var_name, 
+    meta_mat <- rbind(meta_mat, c(st_id=st_id, rexchange=rexchange, st_name=st_name, var_name=var_name, 
                                   time_agg=as.character(time_scale)) )
     #-----
     # get DATA

--- a/R/dB_readZRX2station.R
+++ b/R/dB_readZRX2station.R
@@ -37,6 +37,29 @@ dB_readZRX2station <- function(files, write_csv=FALSE, output_path, do.hourly=FA
     # dummy for station data
     station_data <- list()
     
+    # correct list to exclude void file
+    empty_file <- list()
+    for (f in files)
+    {
+      if (file.info(f)$size == 0)
+      {
+        empty_file[[length(empty_file)+1]] <- f
+        #empty_file = list(empty_file, c=f)
+        files <- files[files != f]
+      }
+    }
+    if (write_csv)
+    {
+      write.csv(as.data.frame(empty_file), file = file.path(output_path, paste("empty_file_list",".csv",sep="")), quote=F, row.names = F, col.names = F)
+    }else{
+      print(as.character(empty_file), quote=T)
+    }
+    if (length(files) == 0)
+    {
+      print("All given files are empty. Execution interrupted.")
+      stop()
+    }
+    
     # read data via loop over files
     for (i in files)
     {


### PR DESCRIPTION
in dB_readZRX:
metadata field are extracted from the description sections instead of using rexchange code (permit to treath rexchange code of the type 123456.ZRX).

in dB_readZRX2station:
empty ZRX file are now skipped (otherwise an error occurred).
A .csv file with the rexchange code of empty file in then produced.
